### PR TITLE
Fix default OpenAI API key variable

### DIFF
--- a/src/Journal.ts
+++ b/src/Journal.ts
@@ -48,7 +48,7 @@ export class Journal {
      */
     constructor(filePath: string, openaiClient?: OpenAI, model = "gpt-4.1-nano") {
         this.filePath = filePath;
-        this.openai = openaiClient ?? new OpenAI({apiKey: process.env.OPENAI_KEY});
+        this.openai = openaiClient ?? new OpenAI({apiKey: process.env.OPENAI_API_KEY});
         this.model = model;
     }
 


### PR DESCRIPTION
## Summary
- use the correct OPENAI_API_KEY environment variable

## Testing
- `npm test` *(fails: `vitest: not found`)*